### PR TITLE
Fix VS 12.0 build error

### DIFF
--- a/netifaces.c
+++ b/netifaces.c
@@ -400,11 +400,12 @@ compare_bits (const void *pva,
 static int
 add_to_family (PyObject *result, int family, PyObject *dict)
 {
+  PyObject *py_family, *list;
   if (!PyDict_Size (dict))
     return TRUE;
 
-  PyObject *py_family = PyInt_FromLong (family);
-  PyObject *list = PyDict_GetItem (result, py_family);
+  py_family = PyInt_FromLong (family);
+  list = PyDict_GetItem (result, py_family);
 
   if (!py_family) {
     Py_DECREF (dict);


### PR DESCRIPTION
This fix the following error:

> c:\python27\include\pymath.h(22) : warning C4273: 'round' : inconsistent dll linkage
>         C:\Program Files\Microsoft Visual Studio 12.0\VC\INCLUDE\math.h(516) : see previous definition of 'round'
> netifaces.c(406) : error C2275: 'PyObject' : illegal use of this type as an expression
>         c:\python27\include\object.h(108) : see declaration of 'PyObject'
> netifaces.c(406) : error C2065: 'py_family' : undeclared identifier
> netifaces.c(407) : error C2065: 'py_family' : undeclared identifier
